### PR TITLE
TELFE-98 set default prefix to add node modal

### DIFF
--- a/src/Components/Diagram/Diagram.tsx
+++ b/src/Components/Diagram/Diagram.tsx
@@ -90,8 +90,9 @@ const DiagramComponent: FC<RdfPanelProps> = observer((props: RdfPanelProps) => {
     props.presenter.deleteEdge(edge.source, edge.target, edge.label as string)
   }
 
-  const onSubmitNode = (name: string): void => {
-    props.presenter.newNodeName = name
+  const onSubmitNode = (prefix: string, name: string): void => {
+    props.presenter.newNodeName = `${prefix}${name}`
+    props.presenter.lastSelectedPrefix = prefix
     props.presenter.addNode()
 
     setOpen(false)
@@ -125,7 +126,7 @@ const DiagramComponent: FC<RdfPanelProps> = observer((props: RdfPanelProps) => {
       } />
       <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
     </ReactFlow>
-    {open && <NodeDialog title="Add node details:" onClose={onCloseDialog} options={Object.keys(props.presenter.viewModel.prefixes)} onSubmit={onSubmitNode} />}
+    {open && <NodeDialog title="Add node details:" onClose={onCloseDialog} options={Object.keys(props.presenter.viewModel.prefixes)} onSubmit={onSubmitNode} lastSelectedPrefix={props.presenter.viewModel.lastSelectedPrefix} />}
     {edgeDialogOpen && <EdgeDialog title="Add edge details:" onClose={onCloseDialog} options={props.presenter.viewModel.relationships} onSubmit={onSubmitEdge} />}
   </>
   )

--- a/src/Components/Diagram/NodeDialog.tsx
+++ b/src/Components/Diagram/NodeDialog.tsx
@@ -1,23 +1,33 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { TeliAutocomplete, TeliButton, TeliTextField } from "@telicent-oss/ds"
 import { DialogBox } from '../../lib/DialogBox/DialogBox'
 
 interface NodeDialogProps {
   onClose: () => void
-  onSubmit: (name: string) => void
+  onSubmit: (prefix: string, name: string) => void
   options: Array<string>
   title: string
+  lastSelectedPrefix: string
 }
-export const NodeDialog: FC<NodeDialogProps> = ({ options, onClose, title, onSubmit }) => {
-  const [selectedPrefix, setSelectedPrefix] = useState<string>(options[0])
+export const NodeDialog: FC<NodeDialogProps> = ({ options, onClose, title, onSubmit, lastSelectedPrefix }) => {
+  const [selectedPrefix, setSelectedPrefix] = useState<string>(lastSelectedPrefix)
   const [name, setName] = useState<string>(crypto.randomUUID())
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        onHandleSubmit()
+      }
+    }
+    document.addEventListener('keypress', handleKeyPress)
+    return () => {
+      document.removeEventListener('keypress', handleKeyPress)
+    }
+  }, [])
 
   const onChangeName: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     event.preventDefault()
-    if (!event.target.value) {
-      setName(crypto.randomUUID())
-      return
-    }
+    if (!event.target.value) return
 
     setName(event.target.value)
   }
@@ -36,14 +46,14 @@ export const NodeDialog: FC<NodeDialogProps> = ({ options, onClose, title, onSub
       console.warn("Node must have valid inputs")
       return
     }
-    onSubmit(`${selectedPrefix}${name}`)
+    onSubmit(selectedPrefix, name)
   }
 
   return (
     <DialogBox onClose={onClose} title={title}>
       <div className="dark:text-whiteSmoke flex flex-col gap-y-8 rounded">
         <div className='flex gap-x-2'>
-          <TeliAutocomplete options={options} width={150} label="Prefix" onChange={onChangePrefix} />
+          <TeliAutocomplete options={options} width={150} label="Prefix" onChange={onChangePrefix} value={selectedPrefix} />
           <TeliTextField id="node-name" label="Node name" onChange={onChangeName} value={name} required />
         </div>
         <div className='flex justify-end w-full'>

--- a/src/rdfInstanceViewer/RdfInstancePresenter.ts
+++ b/src/rdfInstanceViewer/RdfInstancePresenter.ts
@@ -50,6 +50,8 @@ export class RdfInstancePresenter {
   newEdgeSource: string | null = null
   newEdgeTarget: string | null = null
 
+  lastSelectedPrefix: string | null = null
+
   constructor() {
     makeObservable(this, {
       handleRdfInput: action,
@@ -64,8 +66,16 @@ export class RdfInstancePresenter {
       resetNewEdge: action,
       deleteNodeAndAssociatedEdges: action,
       deleteEdge: action,
-      formatRdfText: action
+      formatRdfText: action,
+      reset: action
     })
+    this.reset()
+  }
+
+  reset() {
+    this.resetNewEdge()
+    this.resetNewNode()
+    this.lastSelectedPrefix = "data:"
   }
 
   get viewModel() {
@@ -82,6 +92,7 @@ export class RdfInstancePresenter {
       relationships: this.rdfInstanceRepository.relationships.map((relationship => this.rdfInstanceRepository.getUserFriendlyURI(relationship))),
       iesObjects: this.rdfInstanceRepository.iesObjects.map((iesObject) => iesObject),
       prefixes: this.rdfInstanceRepository.prefixes,
+      lastSelectedPrefix: this.lastSelectedPrefix ?? this.rdfInstanceRepository.prefixes[0]
     }
   }
 

--- a/src/rdfInstanceViewer/RdfInstanceRepository.ts
+++ b/src/rdfInstanceViewer/RdfInstanceRepository.ts
@@ -63,6 +63,7 @@ export class RdfInstanceRepository {
     this.nodes = []
     // TODO: set this up properly later
     this.selectedRelationship = this.relationships[0]
+    this.addPrefix("data", "http://example.com/rdf/testdata#")
     this.loadPrefixes()
   }
 

--- a/src/rdfInstanceViewer/__tests__/RdfInstance.spec.ts
+++ b/src/rdfInstanceViewer/__tests__/RdfInstance.spec.ts
@@ -4,7 +4,7 @@ import { AppTestHarness } from "../../TestTools/AppTestHarness";
 import { QuadError, RdfInstancePresenter } from "../RdfInstancePresenter";
 import { FakeHttpGateway } from "../../Core/FakeHttpGateway";
 import { Types } from "../../Core/Types";
-import { GetRawPrefixDataStub, GetPrefixObjectStub } from "../../TestTools/GetRdfInputStub";
+import { GetRawPrefixDataStub } from "../../TestTools/GetRdfInputStub";
 import { RdfInstanceRepository } from "../RdfInstanceRepository";
 import { Quad } from "@rdfjs/types";
 import { GetEdgeQuadStub, GetNodeQuadStub } from "../../TestTools/GetTripleStub";
@@ -30,8 +30,30 @@ describe('rdfInstance', () => {
         // pivot
         dataGateway.getPrefixes = vi.fn().mockImplementation(() => GetRawPrefixDataStub)
 
-        expect(rdfInstancePresenter?.viewModel.rdf).toBe("@prefix : <http://telicent.io/ontology/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\n@prefix telicent: <http://telicent.io/ontology/> .\n\n")
-        expect(rdfInstanceRepository?.prefixes).toStrictEqual(GetPrefixObjectStub)
+        expect(rdfInstancePresenter?.viewModel.rdf).toMatchInlineSnapshot(`
+          "@prefix : <http://telicent.io/ontology/> .
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix dc: <http://purl.org/dc/elements/1.1/> .
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+          @prefix owl: <http://www.w3.org/2002/07/owl#> .
+          @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
+
+          "
+        `)
+        expect(rdfInstanceRepository?.prefixes).toMatchInlineSnapshot(`
+          {
+            ":": "http://telicent.io/ontology/",
+            "data:": "http://example.com/rdf/testdata#",
+            "dc:": "http://purl.org/dc/elements/1.1/",
+            "owl:": "http://www.w3.org/2002/07/owl#",
+            "rdf:": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs:": "http://www.w3.org/2000/01/rdf-schema#",
+            "telicent:": "http://telicent.io/ontology/",
+            "xsd:": "http://www.w3.org/2001/XMLSchema#",
+          }
+        `)
       } else {
         assert.fail("dataGateway is null")
       }
@@ -83,16 +105,17 @@ describe('rdfInstance', () => {
         expect(rdfInstancePresenter.viewModel.nodes).toEqual([])
         expect(rdfInstancePresenter.viewModel.edges).toEqual([])
         expect(rdfInstancePresenter.viewModel.rdf).toMatchInlineSnapshot(`
-        "@prefix : <http://telicent.io/ontology/> .
-        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-        @prefix dc: <http://purl.org/dc/elements/1.1/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix owl: <http://www.w3.org/2002/07/owl#> .
-        @prefix telicent: <http://telicent.io/ontology/> .
+          "@prefix : <http://telicent.io/ontology/> .
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix dc: <http://purl.org/dc/elements/1.1/> .
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+          @prefix owl: <http://www.w3.org/2002/07/owl#> .
+          @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
-        "
-      `)
+          "
+        `)
 
         // Pivot
         rdfInstancePresenter.onEndPartial(nodes, edges, objects, quads)()
@@ -129,18 +152,19 @@ describe('rdfInstance', () => {
         ]
       `)
         expect(rdfInstancePresenter.viewModel.rdf).toMatchInlineSnapshot(`
-        "@prefix : <http://telicent.io/ontology/> .
-        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-        @prefix dc: <http://purl.org/dc/elements/1.1/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix owl: <http://www.w3.org/2002/07/owl#> .
-        @prefix telicent: <http://telicent.io/ontology/> .
+          "@prefix : <http://telicent.io/ontology/> .
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix dc: <http://purl.org/dc/elements/1.1/> .
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+          @prefix owl: <http://www.w3.org/2002/07/owl#> .
+          @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
-        http://telicent.io/data#0b791546-4f5c-4d58-9b62-7b7608af6468 a http://ies.data.gov.uk/ontology/ies4#Person .
-        https://telicent.io/#0b791546-4f5c-4d58-9b62-7b7608af6468 http://ies.data.gov.uk/ontology/ies4#aCopyOf http://telicent.io/data#6cd17931-5c29-4cb9-8c26-745939aa9335 .
-        "
-      `)
+          http://telicent.io/data#0b791546-4f5c-4d58-9b62-7b7608af6468 a http://ies.data.gov.uk/ontology/ies4#Person .
+          https://telicent.io/#0b791546-4f5c-4d58-9b62-7b7608af6468 http://ies.data.gov.uk/ontology/ies4#aCopyOf http://telicent.io/data#6cd17931-5c29-4cb9-8c26-745939aa9335 .
+          "
+        `)
       } else {
         assert.fail("rdfInstancePresenter is null")
       }
@@ -210,16 +234,17 @@ describe('rdfInstance', () => {
       if (rdfInstancePresenter) {
         rdfInstancePresenter.addNode()
         expect(rdfInstancePresenter.viewModel.rdf).toMatchInlineSnapshot(`
-        "@prefix : <http://telicent.io/ontology/> .
-        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-        @prefix dc: <http://purl.org/dc/elements/1.1/> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-        @prefix owl: <http://www.w3.org/2002/07/owl#> .
-        @prefix telicent: <http://telicent.io/ontology/> .
+          "@prefix : <http://telicent.io/ontology/> .
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix dc: <http://purl.org/dc/elements/1.1/> .
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+          @prefix owl: <http://www.w3.org/2002/07/owl#> .
+          @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
-        "
-      `)
+          "
+        `)
       } else {
         assert.fail("rdfInstancePresenter is null")
       }
@@ -238,6 +263,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           newName a newType ."
@@ -260,6 +286,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
           "
         `)
@@ -284,6 +311,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           edgeTarget edgeType edgeSource ."
@@ -322,6 +350,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           nodeA a nodeAType .
@@ -337,6 +366,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           nodeB a nodeBType ."
@@ -358,6 +388,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
           "
         `)
@@ -391,6 +422,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           nodeA a nodeAType .
@@ -410,6 +442,7 @@ describe('rdfInstance', () => {
           @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
           @prefix owl: <http://www.w3.org/2002/07/owl#> .
           @prefix telicent: <http://telicent.io/ontology/> .
+          @prefix data: <http://example.com/rdf/testdata#> .
 
 
           nodeA a nodeAType .


### PR DESCRIPTION
TELFE-98

- Adds data: prefix when app loads
- Sets the last selected prefix to be `data:` by default
- Listens for enter keypress to invoke submit function